### PR TITLE
Map sample names to tube ids

### DIFF
--- a/qp_klp/klp.py
+++ b/qp_klp/klp.py
@@ -57,7 +57,7 @@ def map_sample_names_to_tube_ids(sn_tid_map_by_proj, output_dir):
                                 sample_name]
                             df.at[i, "sample_name"] = sample_name
                     # write modified results back out to file
-                    df.to_csv(prep_file, sep="\t")
+                    df.to_csv(prep_file, index=False, sep="\t")
                     break
 
 

--- a/qp_klp/klp.py
+++ b/qp_klp/klp.py
@@ -23,9 +23,40 @@ from metapool.sample_sheet import sample_sheet_to_dataframe
 from metapool.prep import remove_qiita_id
 from random import choices
 import pandas as pd
+import os
 
 
 CONFIG_FP = environ["QP_KLP_CONFIG_FP"]
+
+
+def map_sample_names_to_tube_ids(sn_tid_map_by_proj, output_dir):
+    prep_files = []
+    for root, dirs, files in os.walk(output_dir):
+        for prep_file in files:
+            # sanity check the os.walk results
+            if prep_file.endswith('.tsv'):
+                # store the full path to the prep-file.
+                prep_files.append(join(root, prep_file))
+
+    for project in sn_tid_map_by_proj:
+        if sn_tid_map_by_proj[project] is not None:
+            # this project has tube-ids registered in Qiita.
+            # find the prep-file associated with this project.
+            for prep_file in prep_files:
+                # not the best check but good enough for now.
+                if project in prep_file:
+                    df = pd.read_csv(prep_file, sep='\t')
+                    # save a copy of sample_names column as 'old_sample_names'
+                    df['old_sample_names'] = df['sample_names']
+                    for i in df.index:
+                        sample_name = df.at[i, "sample_names"]
+                        # remove any leading zeroes if they exist
+                        sample_name = sample_name.lstrip('0')
+                        sample_name = sn_tid_map_by_proj[project][sample_name]
+                        df.at[i, "sample_names"] = sample_name
+                    # write modified results back out to file
+                    df.to_csv(prep_file, sep="\t")
+                    break
 
 
 class FailedSamplesRecord:
@@ -353,11 +384,13 @@ def sequence_processing_pipeline(qclient, job_id, parameters, out_dir):
             config['seqpro_path'],
             project_list,
             config['modules_to_load'],
-            job_id,
-            sn_tid_map_by_project)
+            job_id)
 
         if not skip_exec:
             gpf_job.run(callback=_update_job_step)
+
+        map_sample_names_to_tube_ids(sn_tid_map_by_project,
+                                     join(pipeline.output_path, 'PrepFiles'))
 
         _update_current_message("Step 6 of 6: Copying results to archive")
 


### PR DESCRIPTION
qp-klp can now scan Qiita for tube-ids and if they are present with a study, it can modify prep-files on-the-fly to reflect the proper sample-name.