### PR TITLE
Fix read csv in update_blanks_in_qiita

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,3 @@ dmypy.json
 
 # Plugin configuration file
 configuration.json
-
-# test generated files
-qp_klp/tests/*

--- a/qp_klp/klp_util.py
+++ b/qp_klp/klp_util.py
@@ -15,7 +15,7 @@ def update_blanks_in_qiita(sifs, qclient):
 
         # SIFs only contain BLANKs. Get the list of potentially new BLANKs.
         blank_ids = [i for i in df['sample_name'] if 'blank' in i.lower()]
-        blanks = df[df['sample_name'].isin(blank_ids)]
+        blanks = df[df['sample_name'].isin(blank_ids)]['sample_name']
         if len(blanks) == 0:
             # we have nothing to do so let's return early
             return

--- a/qp_klp/klp_util.py
+++ b/qp_klp/klp_util.py
@@ -8,13 +8,17 @@ def update_blanks_in_qiita(sifs, qclient):
         # get study_id from sif_file_name ...something_14385_blanks.tsv
         study_id = sif_path.split('_')[-2]
 
-        df = pd.read_csv(sif_path, delimiter='\t')
+        df = pd.read_csv(sif_path, delimiter='\t', dtype=str)
 
         # Prepend study_id to make them compatible w/list from Qiita.
         df['sample_name'] = f'{study_id}.' + df['sample_name'].astype(str)
 
         # SIFs only contain BLANKs. Get the list of potentially new BLANKs.
-        blanks = df['sample_name']
+        blank_ids = [i for i in df['sample_name'] if 'blank' in i.lower()]
+        blanks = df[df['sample_name'].isin(blank_ids)]
+        if len(blanks) == 0:
+            # we have nothing to do so let's return early
+            return
 
         # Get list of BLANKs already registered in Qiita.
         from_qiita = qclient.get(f'/api/v1/study/{study_id}/samples')

--- a/qp_klp/tests/sample_info_file_1_bad_blanks.tsv
+++ b/qp_klp/tests/sample_info_file_1_bad_blanks.tsv
@@ -1,0 +1,5 @@
+sample_name	collection_timestamp	elevation	empo_1	empo_2	empo_3	env_biome	env_feature	env_material	env_package	geo_loc_name	host_subject_id	latitude	longitude	sample_type	scientific_name	taxon_id	description	title	dna_extracted	physical_specimen_location	physical_specimen_remaining
+1.0	2022-1-19	193	Control	Negative	Sterile water blank	urban biome	research facility	sterile water	misc environment	USA:CA:San Diego	BLANK.None.20C.BLANK.1	32.5	-117.25	control blank	metagenome	256318	BLANK.None.20C.BLANK.1	PLUS_Urobiome_Validation_Vaginal	TRUE	UCSD	FALSE
+2.00	2022-1-19	193	Control	Negative	Sterile water blank	urban biome	research facility	sterile water	misc environment	USA:CA:San Diego	BLANK.None.20C.BLANK.2	32.5	-117.25	control blank	metagenome	256318	BLANK.None.20C.BLANK.2	PLUS_Urobiome_Validation_Vaginal	TRUE	UCSD	FALSE
+3.000	2022-1-19	193	Control	Negative	Sterile water blank	urban biome	research facility	sterile water	misc environment	USA:CA:San Diego	BLANK.AssayAssure.20C.BLANK.1	32.5	-117.25	control blank	metagenome	256318	BLANK.AssayAssure.20C.BLANK.1	PLUS_Urobiome_Validation_Vaginal	TRUE	UCSD	FALSE
+

--- a/qp_klp/tests/test_klp.py
+++ b/qp_klp/tests/test_klp.py
@@ -590,6 +590,23 @@ class KLPTests(PluginTestCase):
                     '0B01</td><td>ConvertJob</td></tr></tbody></table>')
             self.assertEqual(obs3, exp3)
 
+    def test_update_blanks_in_qiita_type_inference(self):
+        # Ensure we gracefully handle a situation in which there are no
+        # blanks, and the identifiers are numeric. This is an edge case
+        # that should not occur, but it is worth being defensive.
+        sifs = ['qp_klp/tests/sample_info_file_1_bad_blanks.tsv']
+
+        # we are not adding in any blanks so we should not observe change
+        exp = self.qclient.get('/api/v1/study/1/samples')
+        exp = [x for x in exp if x.startswith('1.BLANK')]
+
+        update_blanks_in_qiita(sifs, self.qclient)
+
+        obs = self.qclient.get('/api/v1/study/1/samples')
+        obs = [x for x in obs if x.startswith('1.BLANK')]
+
+        self.assertEqual(set(obs), set(exp))
+
     def test_update_blanks_in_qiita(self):
         sifs = ['qp_klp/tests/sample_info_file_1_blanks.tsv']
 


### PR DESCRIPTION
The order of commits is inconsequentially backwards -- I didn't catch the unusual entry in `.gitignore` until a few commits in. 

This PR does the following:

- asserts we can provide numeric IDs to `update_blanks_in_qiita`. This is an edge case that we do not expect, but all the more reason to be defensive
- limits the `update_blanks_in_qiita` method to only consider samples with `blank` in their names

I don't have a full dev environment locally so unfortunately I do need to rely on CI for test suite execution. 