### PR TITLE
bug-fixes after testing on qiita-rc

### DIFF
--- a/qp_klp/Step.py
+++ b/qp_klp/Step.py
@@ -916,7 +916,7 @@ class Step:
             self.convert_bcl_to_fastq()
 
         increment_status()
-        if "QCJob" not in skip_steps:
+        if "NuQCJob" not in skip_steps:
             self.quality_control()
 
         increment_status()

--- a/qp_klp/tests/data/process_all_fastq_files.sh
+++ b/qp_klp/tests/data/process_all_fastq_files.sh
@@ -12,7 +12,7 @@
 
 echo "---------------"
 echo "Run details:"
-echo "$SLURM_JOB_NAME $SLURM_JOB_ID $SLURMD_NODENAME"
+echo "$SLURM_JOB_NAME $SLURM_JOB_ID $SLURMD_NODENAME $SLURM_ARRAY_TASK_ID"
 echo "---------------"
 
 if [[ -z "${SLURM_ARRAY_TASK_ID}" ]]; then

--- a/qp_klp/tests/data/process_all_fastq_files.sh
+++ b/qp_klp/tests/data/process_all_fastq_files.sh
@@ -19,11 +19,6 @@ if [[ -z "${SLURM_ARRAY_TASK_ID}" ]]; then
     echo "Not operating within an array"
     exit 1
 fi
-
-if [[ "${SLURM_ARRAY_TASK_MIN}" -ne 1 ]]; then
-    echo "Min array ID is not 1"
-    exit 1
-fi
 if [[ -z ${MMI} ]]; then
     echo "MMI is not set"
     exit 1
@@ -56,11 +51,7 @@ fi
 # DO NOT do this casually. Only do a clean up like this if
 # you know for sure TMPDIR is what you want.
 
-# we might got back to this TMPDIR once the slurm scheduler controls it
-#    TMPDIR=/dev/shm
-# right now, let's use ${OUTPUT}, note that each worker will create a new tmp
-# folder two lines below
-TMPDIR=${OUTPUT}
+TMPDIR=/dev/shm
 export TMPDIR=${TMPDIR}
 export TMPDIR=$(mktemp -d)
 echo $TMPDIR


### PR DESCRIPTION
Here is a PR for the bug-fixes encountered after testing. There is one inconsequential change in mg-scripts for debugging purposes on qiita-rc so I did not include it in a second PR.

seqpro has so far taken four hours to count all of the files in our test job and it is still not finished. My assumption is that if seqpro completes successfully the steps downstream will be successful as well, as they're relatively small and were not affected by any recent changes.

seqpro keeps the generated sequence count for each file in memory. If the interpreter process dies, we can begin the Step() over again but all of the previous work will be lost. One possible solution might be to alter the demux() function to keep a count and write the info out to a json file that can later be read by a modified version of seqpro. This is similar to what it already does with other metadata files found in the run-directory. For existing jobs where NuQCJob has already run, we can write a job script to process them in parallel. That's where my thinking takes me.