### PR TITLE
remove sequencer types info, instead get from kl-metapool

### DIFF
--- a/tests/test_Pipeline.py
+++ b/tests/test_Pipeline.py
@@ -2423,11 +2423,9 @@ class TestInstrumentUtils(unittest.TestCase):
             break
 
         for run_id, run_dir in run_directories:
-            self.assertEqual(iutils.get_instrument_id(run_dir),
-                             exp[run_id]['id'])
             self.assertEqual(iutils.get_instrument_type(run_dir),
                              exp[run_id]['type'])
-            self.assertEqual(iutils.get_date(run_dir),
+            self.assertEqual(iutils._get_date(run_dir),
                              exp[run_id]['date'])
 
 


### PR DESCRIPTION
WILL BREAK UNTIL kl-metapool PR IS ACCEPTED & INSTALLED

This is my suggested change to remove the sequencer type definitions, and the code to get machine prefix from instrument id, from this repo and localize it entirely in kl-metapool.  I have not been able to run tests for this in my dev environment so it should be looked at very carefully :)